### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,19 @@
 - added support for preference change listeners #9
 - added support for double/Double types #10
 
-##1.2.1 (2015-06-15)
+## 1.2.1 (2015-06-15)
 - added support to set nulls for Date values
 - fixed NPE when using Date values
 
-##1.2.0 (2015-05-31)
+## 1.2.0 (2015-05-31)
 - added support for custom types #3
 - removed default value modes
 
-##1.1.0 (2015-05-16)
+## 1.1.0 (2015-05-16)
 - added support for remove methods #8
 
-##1.0.1 (2015-05-15)
+## 1.0.1 (2015-05-15)
 - fixed exception when passing null for string setters #8
 
-##1.0.0 (2015-04-11)
+## 1.0.0 (2015-04-11)
 - initial release

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Download](https://api.bintray.com/packages/martino2k6/maven/storebox/images/download.svg) ](https://bintray.com/martino2k6/maven/storebox/_latestVersion)
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-StoreBox-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/1737)
 
-##Contents##
+## Contents ##
 * [Overview](#overview)
 * [Adding to a project](#adding-to-a-project)
 * [Interface and creation](#defining-an-interface-and-bringing-it-to-life)
@@ -25,7 +25,7 @@
 * [Contributing](#contributing)
 * [License](#license)
 
-##Overview##
+## Overview ##
 StoreBox is an annotation-based library for interacting with Android's [SharedPreferences](http://developer.android.com/reference/android/content/SharedPreferences.html), with the aim take out the the *how* and *where* parts of retrieving/storing values and instead focus on the more important *what* part.
 
 Normally when retrieving or storing values we need to know two pieces of information during each call: the key and the type.
@@ -55,16 +55,16 @@ The caller now doesn't need to worry about the key, neither about what type the 
 
 Read on to find out more details about how StoreBox can be used and how it can be added to an Android project.
 
-##Adding to a project##
+## Adding to a project ##
 StoreBox can be used in Android projects using minimum SDK version 10 and newer (Android 2.3+).
-###JAR###
+### JAR ###
 [v1.4.0 JAR](https://oss.sonatype.org/service/local/repositories/releases/content/net/orange-box/storebox/storebox-lib/1.4.0/storebox-lib-1.4.0.jar)  
 [v1.4.0 JavaDoc JAR](https://oss.sonatype.org/service/local/repositories/releases/content/net/orange-box/storebox/storebox-lib/1.4.0/storebox-lib-1.4.0-javadoc.jar)
-###Gradle###
+### Gradle ###
 ```
 compile 'net.orange-box.storebox:storebox-lib:1.4.0'
 ```
-###Maven###
+### Maven ###
 ```
 <dependency>
   <groupId>net.orange-box.storebox</groupId>
@@ -73,7 +73,7 @@ compile 'net.orange-box.storebox:storebox-lib:1.4.0'
 </dependency>
 ```
 
-##Defining an interface and bringing it to life##
+## Defining an interface and bringing it to life ##
 Simply create a new interface class in your IDE or a text editor, give it an access modifier which suits its use, and name it as appropriate.
 ```Java
 public interface MyPreferences {
@@ -85,7 +85,7 @@ Now you're ready to use [`StoreBox.create()`](https://github.com/martino2k6/Stor
 MyPreferences instance = StoreBox.create(context, MyPreferences.class);
 ```
 
-##Adding get and set methods##
+## Adding get and set methods ##
 If you would like to add a **getter** just add a method to the interface which returns a value and make sure to annotate it using [`@KeyByString`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/method/KeyByString.java) or [`@KeyByResource`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/method/KeyByResource.java).
 ```Java
 @KeyByString("key_nickname")
@@ -104,7 +104,7 @@ void setNickname(String value)
 void setNotifications(boolean value)
 ```
 
-##Specifying defaults for get methods##
+## Specifying defaults for get methods ##
 This can be achieved in two ways, through an argument or by using an annotation.
 
 For the first option the following will work.
@@ -126,7 +126,7 @@ For some types, such as `long`, which cannot be added to the resources an intege
 long getRefreshInterval();
 ```
 
-##Storing and retrieving custom types##
+## Storing and retrieving custom types ##
 Saving custom types, which are not understood by Android's SharedPreferences, can be supported through the use of type adapters. A type adapter implementation can be provided by extending from one of the following classes:
 * [`BaseBooleanTypeAdapter`](storebox-lib/src/main/java/net/orange_box/storebox/adapters/base/BaseBooleanTypeAdapter.java) for storing as a `Boolean`
 * [`BaseFloatTypeAdapter`](storebox-lib/src/main/java/net/orange_box/storebox/adapters/base/BaseFloatTypeAdapter.java) for storing as a `Float` and so on...
@@ -156,7 +156,7 @@ The following types will work out of the box, so type adapters don't need to be 
 
 *Disclaimer: APIs around type adapters may change in the future, as I will keep looking for a less verbose way of achieving the same goal without requiring the use of Gson.*
 
-##Opening different types of preferences##
+## Opening different types of preferences ##
 In all of the examples so far details about what preferences are opened and how have been omitted.
 
 Without any annotation the default shared preferences will be used, but the [`@DefaultSharedPreferences`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/type/DefaultSharedPreferences.java) annotation can be added to the interface definition for explicitness. Likewise, [`@ActivityPreferences`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/type/ActivityPreferences.java) or [`@FilePreferences`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/type/FilePreferences.java) can be used to respectively open preferences private to an activity or to open preferences using a file name.
@@ -220,7 +220,7 @@ public interface ClearMethodExample {
 preferences.clear();
 ```
 
-###Change listeners###
+### Change listeners ###
 Callbacks can be received when a preference value changes through the use of the [`OnPreferenceValueChangedListener`](storebox-lib/src/main/java/net/orange_box/storebox/listeners/OnPreferenceValueChangedListener.java) interface. The listeners need to be parametrised with the type which is used for the value whose changes we would like to listen for. For example, if we would like to listen to changes to the password (from previous examples) then we could define the listener as
 ```Java
 OnPreferenceValueChangedListener<String> listener = new OnPreferenceValueChangedListener<String>() {
@@ -253,7 +253,7 @@ void registerPasswordListeners(OnPreferenceValueChangedListener<String>... liste
 
 **Caution:** StoreBox does not store strong references to the listeners. A strong reference must be kept to the listener for as long as the listener will be required, otherwise it will be susceptible to garbage collection.
 
-###Chaining calls###
+### Chaining calls ###
 With Android's [`SharedPreferences.Editor`](http://developer.android.com/reference/android/content/SharedPreferences.Editor.html) class it is possible to keep chaining put methods as each returns back the `SharedPreferences.Editor` instance. StoreBox allows the same functionality. All that needs to be done is to change the set/remove method definitions to either return interface type itself or `SharedPreferences.Editor`.
 ```Java
 public interface ChainingExample {
@@ -273,7 +273,7 @@ And calls can be chained as
 preferences.setUsername("Joe").setPassword("jOe").removeCountry();
 ```
 
-###Forwarding calls###
+### Forwarding calls ###
 If you would like to access methods from the [`SharedPreferences`](http://developer.android.com/reference/android/content/SharedPreferences.html) or [`SharedPreferences.Editor`](http://developer.android.com/reference/android/content/SharedPreferences.Editor.html), you can do that by extending your interface from either of the above (or even both).
 ```Java
 public interface ForwardingExample extends SharedPreferences, SharedPreferences.Editor {
@@ -287,7 +287,7 @@ String username = preferences.getString("key_username", "");
 preferences.putString("key_username", "Joe").apply();
 ```
 
-###Save modes###
+### Save modes ###
 Changes to preferences can normally be saved on Android either through `apply()` or `commit()`. Which method gets used can be customised in StoreBox through the use of the [`@SaveOption`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/option/SaveOption.java) annotation.
 
 Unlike any of the previous annotations `@SaveOption` can be used to annotate both the interface as well as individual set/remove methods, however an annotation at method-level will take precedence over an interface annotation.
@@ -306,7 +306,7 @@ public interface SaveModeExample {
 }
 ```
 
-###Versioning###
+### Versioning ###
 StoreBox supports versioning of preferences through the use of the [`@PreferencesVersion`](storebox-lib/src/main/java/net/orange_box/storebox/annotations/type/PreferencesVersion.java) interface-level annotation, in a similar fashion to Android's [`SQLiteOpenHelper`](http://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper.html). This functionality may be required in the case when the schema of the preferences needs to be changed, such as when a key or type of a preference changes, an enum constant is added/renamed/removed, or a class which is being stored in the preferences changes internally. The `@PreferencesVersion` annotation needs to be added to the interface which will be used with `StoreBox.create()`.
 
 By default, without the `@PreferencesVersion` annotation, the version used is assumed to be `0`. The first time a change is required the `version` for the annotation should be set to `1`, with the value being incremented for any subsequent changes. To provide the logic for handling version upgrades a `handler` class extending from [`PreferencesVersionHandler`](storebox-lib/src/main/java/net/orange_box/storebox/PreferencesVersionHandler.java) needs to be specified.
@@ -336,7 +336,7 @@ For an initial upgrade from `0` to `1` the `onUpgrade` method will be called wit
 
 The versions are also independent of each other, and apply only to specific preference files. For example, you could have a shared preferences with *version X*, *activity A* preferences with *version Y*, and *activity B* preferences with *version Z*. Or none at all, if versioning is not needed.
 
-###Obtaining a more customised instance at run-time###
+### Obtaining a more customised instance at run-time ###
 As previously described you can build an instance of your interface using `StoreBox.create()`, however if you'd like to override at run-time any annotations you can use [`StoreBox.Builder`](storebox-lib/src/main/java/net/orange_box/storebox/StoreBox.java) and apply different options.
 ```Java
 MyPreferences preferences =
@@ -345,7 +345,7 @@ MyPreferences preferences =
         .build()
 ```
 
-###Defaults###
+### Defaults ###
 Given the minimum amount of details provided to the interface and method definitions through the use of StoreBox's annotations, the following defaults will get used:
 * Preferences type: Default shared preferences
 * Preferences mode: Private
@@ -361,15 +361,15 @@ If you are using ProGuard add the following lines to your configuration.
 
 ```
 
-##Contributing##
+## Contributing ##
 Any contributions thorough pull requests as well as raised issues (bugs are rated just as highly as features!) will be welcome and highly appreciated.
 
 If you would like to submit a pull request please make sure to do so against the develop branch, and please follow a similar code style to the one used in the existing code base. Running the tests before and after any changes is highly recommended, just as is adding new test cases.
 
-###Contributors###
+### Contributors ###
 * [cr5315](https://github.com/cr5315)
 
-##License##
+## License ##
 ```
 Copyright 2015 Martin Bella
 

--- a/examples/proguard/README.md
+++ b/examples/proguard/README.md
@@ -1,2 +1,2 @@
-###StoreBox Harness###
+### StoreBox Harness ###
 The harness module for StoreBox which uses the ```lib``` module for instrumenting the library and running automated tests.

--- a/storebox-harness/README.md
+++ b/storebox-harness/README.md
@@ -1,2 +1,2 @@
-###StoreBox Harness###
+### StoreBox Harness ###
 The harness module for StoreBox which uses the ```lib``` module for instrumenting the library and running automated tests.

--- a/storebox-lib/README.md
+++ b/storebox-lib/README.md
@@ -1,2 +1,2 @@
-###StoreBox Lib###
+### StoreBox Lib ###
 The library module for StoreBox that gets published to Maven.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
